### PR TITLE
Add support for legacy SSL negotiation

### DIFF
--- a/services/downloader.py
+++ b/services/downloader.py
@@ -3,16 +3,29 @@ from string import ascii_lowercase
 from concurrent.futures import as_completed
 from requests.adapters import HTTPAdapter
 from requests_futures.sessions import FuturesSession
+from ssl import create_default_context, Purpose
 from urllib3.util import Retry
 
 from services.parser import Parser
 
 URL = 'https://sle-p.transportstyrelsen.se/extweb/sv-se/sokluftfartyg'
 
+class HttpAdapterWithLegacySsl(HTTPAdapter):
+
+    def __init__(self, **kwargs):
+        OP_LEGACY_SERVER_CONNECT = 4  # Available as ssl.OP_LEGACY_SERVER_CONNECT in Python 3.12
+        self.ssl_context = create_default_context(Purpose.SERVER_AUTH)
+        self.ssl_context.options |= OP_LEGACY_SERVER_CONNECT
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        HTTPAdapter.init_poolmanager(self, *args, ssl_context=self.ssl_context, **kwargs)
+
+
 class Downloader(object):
 
     def __init__(self):
-        adapter = HTTPAdapter(max_retries=Retry(total=10, backoff_factor=0.1))
+        adapter = HttpAdapterWithLegacySsl(max_retries=Retry(total=10, backoff_factor=0.1))
 
         self.s = FuturesSession(max_workers=30)
         self.s.mount('https://', adapter)


### PR DESCRIPTION
Ubuntu 22.04 has a new OpenSSL, which is too strict and causes the scheduled workflow to fail.

Fix based on https://github.com/urllib3/urllib3/issues/2653

Example of a successful run: https://github.com/al42and/oppna-luftfartygsregistret/actions/runs/3867414536/jobs/6592176174

Another option is to use `ubuntu-20.04` instead of `ubuntu-latest`.