### PR TITLE
Fix Transportstyrelsen's base url

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -8,8 +8,8 @@ jobs:
     name: Fetch the register
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - run: pip3 install -r requirements.txt

--- a/services/downloader.py
+++ b/services/downloader.py
@@ -8,7 +8,7 @@ from urllib3.util import Retry
 
 from services.parser import Parser
 
-URL = 'https://sle-p.transportstyrelsen.se/extweb/sv-se/sokluftfartyg'
+URL = 'https://etjanster-luftfart.transportstyrelsen.se/sv-se/sokluftfartyg'
 
 class HttpAdapterWithLegacySsl(HTTPAdapter):
 


### PR DESCRIPTION
Transportstyrelsen changed their URL, but nothing else.

I also bumped GitHub actions' versions due to a deprecation warning. It's not needed for the fix.